### PR TITLE
TimelinessDateTime expects integers not string.

### DIFF
--- a/lib/validates_timeliness/action_view/instance_tag.rb
+++ b/lib/validates_timeliness/action_view/instance_tag.rb
@@ -28,7 +28,7 @@ class TimelinessDateTime
           attr_accessor :year, :month, :day, :hour, :min, :sec
 
 
-          def initialize(year, month, day, hour, min, sec)
+          def initialize(year=nil, month=nil, day=nil, hour=nil, min=nil, sec=nil)
 
             @year  = year
             @month = month


### PR DESCRIPTION
This fixes the issue discussed here: https://github.com/adzap/validates_timeliness/issues/28
