### PR TITLE
fixes a problem that results from an attempt do nil.include? later

### DIFF
--- a/lib/validates_timeliness/active_record/attribute_methods.rb
+++ b/lib/validates_timeliness/active_record/attribute_methods.rb
@@ -62,7 +62,7 @@ module ValidatesTimeliness
           # Hack to get around instance_method_already_implemented? caching the
           # methods in the ivar. It then appears to subsequent calls that the
           # methods defined here, have not been and get defined again.
-          @_defined_class_methods = nil
+          @_defined_class_methods = Set.new
 
           define_attribute_methods_without_timeliness
           # add generated methods which is a Set object hence no += method


### PR DESCRIPTION
I encountered this in testing.

I see that 3.0 does not work the same way, but maybe this is useful to others who are still on rails 2.3.
