### PR TITLE
New config option to force to select all the fields on a date_select with a prompt

### DIFF
--- a/lib/generators/validates_timeliness/templates/validates_timeliness.rb
+++ b/lib/generators/validates_timeliness/templates/validates_timeliness.rb
@@ -17,6 +17,9 @@ ValidatesTimeliness.setup do |config|
   # Handle multiparameter date/time values strictly
   # config.enable_multiparameter_extension!
   #
+  # Force the date_select to require all date/time fields (meaning not accepting blank, empty or nil) but redisplay invalid values when available.
+  # config.require_all_date_fields = true
+  #
   # Shorthand date and time symbols for restrictions
   # config.restriction_shorthand_symbols.update(
   #   :now   => lambda { Time.current },

--- a/lib/validates_timeliness.rb
+++ b/lib/validates_timeliness.rb
@@ -45,6 +45,11 @@ module ValidatesTimeliness
   mattr_accessor :use_plugin_parser
   @@use_plugin_parser = false
 
+  # Require all date fields, used to force the user to pick a value in all the select fields for the date
+  mattr_accessor :require_all_date_fields
+  @@require_all_date_fields= false
+
+
   # Default timezone
   self.default_timezone = :utc
 

--- a/lib/validates_timeliness/extensions/multiparameter_handler.rb
+++ b/lib/validates_timeliness/extensions/multiparameter_handler.rb
@@ -39,12 +39,10 @@ module ValidatesTimeliness
         callstack.each do |name, values_with_empty_parameters|
           begin
             klass = (self.class.reflect_on_aggregation(name.to_sym) || column_for_attribute(name)).klass
-            values = values_with_empty_parameters.reject { |v| v.nil? }
-
-            if values.empty?
+            values = values_with_empty_parameters.reject { |v| v.nil? || (ValidatesTimeliness.require_all_date_fields && v.zero? ) }
+            if values.empty? || (ValidatesTimeliness.require_all_date_fields && values.size < 3)
               send(name + "=", nil)
             else
-
               value = if Time == klass
                 instantiate_time_object(name, values)
               elsif Date == klass

--- a/spec/validates_timeliness/extensions/multiparameter_handler_spec.rb
+++ b/spec/validates_timeliness/extensions/multiparameter_handler_spec.rb
@@ -25,6 +25,26 @@ describe ValidatesTimeliness::Extensions::MultiparameterHandler do
       multiparameter_attribute(:birth_date, [2000, 2, 28])
       employee.birth_date_before_type_cast.should be_kind_of(Date)
     end
+
+    context "config require_all_fields" do
+      it 'should not return a date for incomplete values' do
+        ValidatesTimeliness.require_all_date_fields = true
+        multiparameter_attribute(:birth_date, [2000])
+        employee.birth_date_before_type_cast.should be_nil
+      end
+
+      it 'should not return a date value for an incomplete date if the require' do
+        ValidatesTimeliness.require_all_date_fields = true
+        multiparameter_attribute(:birth_date, [2000,0,0])
+        employee.birth_date_before_type_cast.should be_nil
+      end
+
+      it 'should require a Date value for an incomplete date' do
+        ValidatesTimeliness.require_all_date_fields = false
+        multiparameter_attribute(:birth_date, [2000])
+        employee.birth_date_before_type_cast.should be_kind_of(Date)
+      end
+    end
   end
 
   def multiparameter_attribute(name, values)


### PR DESCRIPTION
Adding a new config option to force the user to select all the fields for setting a date. The intention of this config option is not allow blanks but enable prompts in the date_select and force the user to choose all
the date fields.
