### PR TITLE
Remove deprecated InstanceMethods module when using AS::Concern

### DIFF
--- a/lib/validates_timeliness/attribute_methods.rb
+++ b/lib/validates_timeliness/attribute_methods.rb
@@ -65,15 +65,12 @@ module ValidatesTimeliness
       end
     end
 
-    module InstanceMethods
-      def _timeliness_raw_value_for(attr_name)
-        @timeliness_cache && @timeliness_cache[attr_name.to_s]
-      end
-
-      def _clear_timeliness_cache
-        @timeliness_cache = {}
-      end
+    def _timeliness_raw_value_for(attr_name)
+      @timeliness_cache && @timeliness_cache[attr_name.to_s]
     end
 
+    def _clear_timeliness_cache
+      @timeliness_cache = {}
+    end
   end
 end

--- a/lib/validates_timeliness/extensions/date_time_select.rb
+++ b/lib/validates_timeliness/extensions/date_time_select.rb
@@ -15,11 +15,11 @@ module ValidatesTimeliness
 
       class TimelinessDateTime
         attr_accessor :year, :month, :day, :hour, :min, :sec
-        
+
         def initialize(year, month, day, hour, min, sec)
           @year, @month, @day, @hour, @min, @sec = year, month, day, hour, min, sec
         end
-        
+
         # adapted from activesupport/lib/active_support/core_ext/date_time/calculations.rb, line 36 (3.0.7)
         def change(options)
           TimelinessDateTime.new(
@@ -30,35 +30,32 @@ module ValidatesTimeliness
             options[:min]   || (options[:hour] ? 0 : min),
             options[:sec]   || ((options[:hour] || options[:min]) ? 0 : sec)
           )
-        end        
-      end
-
-      module InstanceMethods
-        def datetime_selector_with_timeliness(*args)
-          @timeliness_date_or_time_tag = true
-          datetime_selector_without_timeliness(*args)
-        end
-
-        def value_with_timeliness(object)
-          unless @timeliness_date_or_time_tag && @template_object.params[@object_name]
-            return value_without_timeliness(object)
-          end
-          
-          @template_object.params[@object_name]
-
-          pairs = @template_object.params[@object_name].select {|k,v| k =~ /^#{@method_name}\(/ }
-          return value_without_timeliness(object) if pairs.empty?
-
-          values = [nil] * 6
-          pairs.map do |(param, value)|
-            position = param.scan(/\((\d+)\w+\)/).first.first
-            values[position.to_i-1] = value.to_i
-          end
-
-          TimelinessDateTime.new(*values)
         end
       end
 
+      def datetime_selector_with_timeliness(*args)
+        @timeliness_date_or_time_tag = true
+        datetime_selector_without_timeliness(*args)
+      end
+
+      def value_with_timeliness(object)
+        unless @timeliness_date_or_time_tag && @template_object.params[@object_name]
+          return value_without_timeliness(object)
+        end
+
+        @template_object.params[@object_name]
+
+        pairs = @template_object.params[@object_name].select {|k,v| k =~ /^#{@method_name}\(/ }
+        return value_without_timeliness(object) if pairs.empty?
+
+        values = [nil] * 6
+        pairs.map do |(param, value)|
+          position = param.scan(/\((\d+)\w+\)/).first.first
+          values[position.to_i-1] = value.to_i
+        end
+
+        TimelinessDateTime.new(*values)
+      end
     end
   end
 end

--- a/lib/validates_timeliness/orm/active_record.rb
+++ b/lib/validates_timeliness/orm/active_record.rb
@@ -30,13 +30,10 @@ module ValidatesTimeliness
         end
       end
 
-      module InstanceMethods
-        def reload(*args)
-          _clear_timeliness_cache
-          super
-        end
+      def reload(*args)
+        _clear_timeliness_cache
+        super
       end
-
     end
   end
 end


### PR DESCRIPTION
The usage of InstanceMethods module when using ActiveSupport::Concern was deprecated in Rails 3.2. 

I was playing with an application here that uses validates timeliness, and after bumping to 3.2.0.rc1 I started getting some deprecation warnings due to that, so here it is :). My tests are all green with Rails 3.2 and the current validates timeliness stable version.

Another thing, I was willing to bump Rails requirements in the Gemfile, at least for 3.1.3, but decided to ask beforehand whether I should do that or not.

Thanks.
