### PR TITLE
Fix ActiveRecord Date Parsing With Wonky Dates

### DIFF
--- a/lib/validates_timeliness/orm/active_record.rb
+++ b/lib/validates_timeliness/orm/active_record.rb
@@ -58,7 +58,7 @@ module ValidatesTimeliness
               original_value = value
               if value.is_a?(String)\n#{timeliness_type_cast_code(attr_name, 'value')}\nend
               super(value)
-              @attributes['#{attr_name}'] = value
+              write_attribute '#{attr_name}', value
             end
           EOV
           generated_timeliness_methods.module_eval(method_body, __FILE__, line)


### PR DESCRIPTION
This pull request fixes problems describe in issue #80.
### Changes
- Sets the **parsed** value to the record's attributes
- Uses Rails' public API, `#write_attribute` to set the attribute value instead of using instance variables directly
### Concerns
- No regression test. I had trouble getting a regression test that actually worked. I could use some help on this. This patch, however, does work with my application.
