### PR TITLE
Require 'active_model'

### DIFF
--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -1,3 +1,4 @@
+require 'active_model'
 require 'active_model/validator'
 
 module ValidatesTimeliness


### PR DESCRIPTION
Apparently classes (and modules?) are lazily required when using autoload. Prompted by
'uninitialized constant ActiveModel::Validations'. Didn't have this problem until attempting to rails-4-ify an app

see https://github.com/rails/rails/issues/5768
