### PR TITLE
Range with excluded end passed to :between option should be split into :on_or_after and :before options

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -55,7 +55,10 @@ NOTE: You may wish to enable the plugin parser and the extensions to start. Plea
   validates_datetime :finish_time, :after => :start_time # Method symbol
 
   validates_date :booked_at, :on => :create, :on_or_after => :today # See Restriction Shorthand.
-  validates_time :booked_at, :between => ['9.00am', '5:00pm']
+
+  validates_time :booked_at, :between => ['9:00am', '5:00pm'] # On or after 9:00AM and on or before 5:00PM
+  validates_time :booked_at, :between => '9:00am'..'5:00pm' # The same as previous example
+  validates_time :booked_at, :between => '9:00am'...'5:00pm' # On or after 9:00AM and strictly before 5:00PM
 
   validates_time :breakfast_time, :on_or_after => '6:00am',
                                   :on_or_after_message => 'must be after opening time',
@@ -173,8 +176,8 @@ You can also use validation options for custom error messages. The following opt
     :after_message
     :on_or_after_message
 
-Note: There is no :between_message option. The between error message should be defined using the 
-:on_or_before and :on_or_after messages.
+Note: There is no :between_message option. The between error message should be defined using the :on_or_after and :on_or_before
+(:before in case when :between argument is a Range with excluded high value, see Examples) messages.
 
 It is highly recommended you use the I18n system for error messages.
 

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -32,7 +32,12 @@ module ValidatesTimeliness
 
       if range = options.delete(:between)
         raise ArgumentError, ":between must be a Range or an Array" unless range.is_a?(Range) || range.is_a?(Array)
-        options[:on_or_after], options[:on_or_before] = range.first, range.last
+        options[:on_or_after] = range.first
+        if range.is_a?(Range) && range.exclude_end?
+          options[:before] = range.last
+        else
+          options[:on_or_before] = range.last
+        end
       end
 
       @restrictions_to_check = RESTRICTIONS.keys & options.keys

--- a/spec/validates_timeliness/validator_spec.rb
+++ b/spec/validates_timeliness/validator_spec.rb
@@ -115,6 +115,19 @@ describe ValidatesTimeliness::Validator do
         valid!(:birth_date, on_or_before)
       end
     end
+
+    describe "range with excluded end value" do
+      it 'should be split option into :on_or_after and :before values' do
+        on_or_after, before = Date.new(2010,1,1), Date.new(2010,1,3)
+        Person.validates_date :birth_date, :between => on_or_after...before
+        Person.validators.first.options[:on_or_after].should == on_or_after
+        Person.validators.first.options[:before].should == before
+        invalid!(:birth_date, on_or_after - 1, "must be on or after 2010-01-01")
+        invalid!(:birth_date, before, "must be before 2010-01-03")
+        valid!(:birth_date, on_or_after)
+        valid!(:birth_date, before - 1)
+      end
+    end
   end
 
   describe ":ignore_usec option" do
@@ -224,7 +237,7 @@ describe ValidatesTimeliness::Validator do
       Person.validates_date :birth_date, :invalid_date_message => 'custom invalid message'
       invalid!(:birth_date, 'asdf', 'custom invalid message')
     end
-  
+
     it 'should be used for invalid restriction' do
       Person.validates_date :birth_date, :before => Time.now, :before_message => 'custom before message'
       invalid!(:birth_date, Time.now, 'custom before message')


### PR DESCRIPTION
If you use range with excluded end in :between option, e.g.

``` ruby
validates_date :field, between: date1...date2
```

it should be treated as

``` ruby
validates_date :field, on_or_after: date1, before: date2
```

I also added test for that issue.
