### PR TITLE
Fix for running tests in non-Australian timezones

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,6 +57,7 @@ class PersonWithShim < Person
   include TestModelShim
 end
 
+ActiveRecord::Base.default_timezone = :utc
 ActiveRecord::Base.time_zone_aware_attributes = true
 ActiveRecord::Base.establish_connection({:adapter => 'sqlite3', :database => ':memory:'})
 ActiveRecord::Migration.verbose = false

--- a/spec/validates_timeliness/extensions/multiparameter_handler_spec.rb
+++ b/spec/validates_timeliness/extensions/multiparameter_handler_spec.rb
@@ -10,7 +10,7 @@ describe ValidatesTimeliness::Extensions::MultiparameterHandler do
      
     it 'should assign a Time value for valid datetimes' do
       employee = record_with_multiparameter_attribute(:birth_datetime, [2000, 2, 28, 12, 0, 0])
-      employee.birth_datetime_before_type_cast.should eq Time.local(2000, 2, 28, 12, 0, 0)
+      employee.birth_datetime_before_type_cast.should eq Time.zone.local(2000, 2, 28, 12, 0, 0)
     end
 
     it 'should assign a string value for incomplete time' do

--- a/spec/validates_timeliness/orm/active_record_spec.rb
+++ b/spec/validates_timeliness/orm/active_record_spec.rb
@@ -221,7 +221,7 @@ describe ValidatesTimeliness, 'ActiveRecord' do
       Employee.create(:birth_datetime => datetime)
 
       record = Employee.last
-      record.birth_datetime_before_type_cast.should match(/2010-01-01 00:00:00/)
+      record.birth_datetime_before_type_cast.should match(/#{datetime.utc.to_s[0...-4]}/)
     end
 
     context "with plugin parser" do


### PR DESCRIPTION
When runnning `bundle exec rake` in Denmark or for that matter in any other timezone than Australian timezone these two tests fails.
