### PR TITLE
Update to Mongoid 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'appraisal'
 gem 'sqlite3'
 
 group :mongoid do
-  gem 'mongoid', '~> 2.3.0'
+  gem 'mongoid', '>= 3.0'
   gem 'bson_ext'
   gem 'system_timer', :platforms => [:ruby_18]
 end

--- a/lib/validates_timeliness/orm/mongoid.rb
+++ b/lib/validates_timeliness/orm/mongoid.rb
@@ -6,7 +6,7 @@ module ValidatesTimeliness
       # It is best to use the plugin parser to avoid errors on a bad
       # field value in Mongoid. Parser will return nil rather than error.
 
-      module ClassMethods 
+      module ClassMethods
         public
 
         # Mongoid has no bulk attribute method definition hook. It defines
@@ -23,7 +23,7 @@ module ValidatesTimeliness
             Date => :date,
             Time => :time,
             DateTime => :datetime
-          }[fields[attr_name.to_s].type] || :datetime
+          }[fields[database_field_name(attr_name)].type] || :datetime
         end
 
         protected
@@ -33,31 +33,17 @@ module ValidatesTimeliness
 
           "#{var_name} = Timeliness::Parser.parse(value, :#{type})"
         end
-
       end
 
-      module Reload
-        def reload(*args)
-          _clear_timeliness_cache
-          super
-        end
+      def reload(*args)
+        _clear_timeliness_cache
+        super
       end
     end
   end
 end
- 
+
 module Mongoid::Document
   include ValidatesTimeliness::AttributeMethods
   include ValidatesTimeliness::ORM::Mongoid
-
-  # Pre-2.3 reload
-  if (instance_methods & ['reload', :reload]).present?
-    def reload_with_timeliness
-      _clear_timeliness_cache
-      reload_without_timeliness
-    end
-    alias_method_chain :reload, :timeliness
-  else
-    include ValidatesTimeliness::ORM::Mongoid::Reload
-  end
 end


### PR DESCRIPTION
- Now requires Mongoid 3.0 as minimum version (this is the only version to support Rails 3.2; Mongoid 2 is very outdated and few plugins continue to support it.)
- Upgrade specs/helpers for Mongoid 3
- Support Mongoid aliased field names (e.g. field :foo, as: bar, type: String). Includes spec
- Support before_type_cast on Mongoid. No code change was required for this, only a spec change.
- There was one mongoid spec that was previously marked pending. I've found that it now works on Mongoid 3.
- Removed some Mongoid 2.3 and earlier hacks, which simplifies the Mongoid ORM code.