### PR TITLE
Remove #setup method, which is deprecated in Rails 4.

### DIFF
--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -25,7 +25,7 @@ module ValidatesTimeliness
 
     # Prior to version 4.1, Rails will call `#setup`, if defined. This method is deprecated in Rails 4.1 and removed
     # altogether in 4.2.
-    SETUP_DEPRECATED = ActiveRecord.respond_to?(:version) && ActiveRecord.version >= Gem::Version.new('4.1')
+    SETUP_DEPRECATED = ActiveModel.respond_to?(:version) && ActiveModel.version >= Gem::Version.new('4.1')
 
     def self.kind
       :timeliness

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -23,6 +23,10 @@ module ValidatesTimeliness
 
     RESTRICTION_ERROR_MESSAGE = "Error occurred validating %s for %s restriction:\n%s"
 
+    # Prior to version 4.1, Rails will call `#setup`, if defined. This method is deprecated in Rails 4.1 and removed
+    # altogether in 4.2.
+    SETUP_DEPRECATED = ActiveRecord.respond_to?(:version) && ActiveRecord.version >= Gem::Version.new('4.1')
+
     def self.kind
       :timeliness
     end
@@ -53,9 +57,8 @@ module ValidatesTimeliness
       end
     end
 
-    unless method_defined?(:setup) || private_instance_methods.include?(:deprecated_setup)
-      alias_method :setup, :setup_timeliness_validated_attributes
-    end
+    # Provide backwards compatibility for Rails < 4.1, which expects `#setup` to be defined.
+    alias_method :setup, :setup_timeliness_validated_attributes unless SETUP_DEPRECATED
 
     def validate_each(record, attr_name, value)
       raw_value = attribute_raw_value(record, attr_name) || value

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -43,13 +43,18 @@ module ValidatesTimeliness
 
       @restrictions_to_check = RESTRICTIONS.keys & options.keys
       super
+      setup_timeliness_validated_attributes(options[:class]) if options[:class]
     end
 
-    def setup(model)
+    def setup_timeliness_validated_attributes(model)
       if model.respond_to?(:timeliness_validated_attributes)
         model.timeliness_validated_attributes ||= []
         model.timeliness_validated_attributes |= @attributes
       end
+    end
+
+    unless method_defined?(:setup) || private_instance_methods.include?(:deprecated_setup)
+      alias_method :setup, :setup_timeliness_validated_attributes
     end
 
     def validate_each(record, attr_name, value)


### PR DESCRIPTION
Defining `#setup` on Validators is deprecated in Rails 4.1 and is planned to be removed altogether in Rails 4.2. In the meantime, defining `setup` causes deprecation warnings.

This patch is cribbed from a couple of suggested solutions discussed in issue #114 and suppresses deprecation warnings in Rails 4.1 and will work in Rails 4.2, as well as older versions.

I haven't included any tests because I couldn't figure out how to cleanly mimic the different behaviours of different Rails versions.