### PR TITLE
Generate attribute methods once instead of on each object creation

### DIFF
--- a/lib/validates_timeliness/orm/active_record.rb
+++ b/lib/validates_timeliness/orm/active_record.rb
@@ -23,7 +23,9 @@ module ValidatesTimeliness
 
         def define_attribute_methods
           super.tap do |attribute_methods_generated|
+            return false if @timeliness_methods_generated
             define_timeliness_methods true
+            @timeliness_methods_generated = true
           end
         end
 


### PR DESCRIPTION
This is a memory and performance improvement change.

The attribute methods for timeliness are generated at each object creation instead of once, at first creation like AR attribute methods. Since creating those methods uses `module_eval` it's quite slow when it's done each `Model.new`.

For more details on the performance improvement, see the same change on John Carney's fork: https://github.com/johncarney/validates_timeliness/pull/6