### PR TITLE
Attribute method test

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ Time.zone = 'Australia/Melbourne'
 
 LOCALE_PATH = File.expand_path(File.dirname(__FILE__) + '/../lib/generators/validates_timeliness/templates/en.yml')
 I18n.load_path.unshift(LOCALE_PATH)
+I18n.config.enforce_available_locales = false
 
 # Extend TestModel as you would another ORM/ODM module
 module TestModelShim

--- a/spec/validates_timeliness/conversion_spec.rb
+++ b/spec/validates_timeliness/conversion_spec.rb
@@ -69,7 +69,7 @@ describe ValidatesTimeliness::Conversion do
         value = Time.utc(2010, 1, 1, 12, 34, 56)
         result = type_cast_value(value, :datetime)
         result.should == Time.zone.local(2010, 1, 1, 23, 34, 56)
-        result.zone.should == 'EST'
+        result.zone.should == 'AEDT'
       end
 
       it 'should return nil for invalid value types' do
@@ -90,7 +90,7 @@ describe ValidatesTimeliness::Conversion do
         value = Time.utc(2010, 1, 1, 12, 34, 56, 10000)
         result = type_cast_value(value, :datetime)
         result.should == Time.zone.local(2010, 1, 1, 23, 34, 56)
-        result.zone.should == 'EST'
+        result.zone.should == 'AEDT'
       end
     end
   end

--- a/spec/validates_timeliness/orm/active_record_spec.rb
+++ b/spec/validates_timeliness/orm/active_record_spec.rb
@@ -237,6 +237,12 @@ describe ValidatesTimeliness, 'ActiveRecord' do
   end
 
   context "define_attribute_methods" do
+    it "defines the attribute methods once" do
+      expect(Employee).to receive(:define_timeliness_methods).and_call_original
+      Employee.new
+      Employee.new
+    end
+
     it "returns a falsy value if the attribute methods have already been generated" do
       Employee.define_attribute_methods.should be_false
     end


### PR DESCRIPTION
For #129 

Actually the test will pass without the changes in #128 because the problem only happens on Rails 4 and currently the Gemfile is locked on Rails 3. Changing to Rails 4 would require pulling in changes from other forks first.

You can keep #129 open until you can check that this new test addresses the issue.