### PR TITLE
Added spec to investigate nil and blank issue

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,6 +65,7 @@ ActiveRecord::Schema.define(:version => 1) do
     t.date     :birth_date
     t.time     :birth_time
     t.datetime :birth_datetime
+    t.date     :some_other_date
   end
 end
 

--- a/spec/validates_timeliness/orm/active_record_spec.rb
+++ b/spec/validates_timeliness/orm/active_record_spec.rb
@@ -35,6 +35,31 @@ RSpec.describe ValidatesTimeliness, 'ActiveRecord' do
       record.valid?
       expect(record.errors[:birth_date]).to be_empty
     end
+
+    context 'with hash syntax' do
+      let(:klass) do
+        Class.new(ActiveRecord::Base) do
+          self.table_name = 'employees'
+          validates_date :birth_date, { allow_nil: true, allow_blank: true }
+        end
+      end
+
+      it 'allows nil' do
+        record = klass.new
+        record[:birth_date] = nil
+        expect(record.valid?).to eq(true)
+        expect(record.errors.empty?).to eq(true)
+      end
+
+      it 'allows blank' do
+        record = klass.new
+        ['', {}, []].each do |blank_val|
+          record[:birth_date] = blank_val
+          expect(record.valid?).to eq(true)
+          expect(record.errors.empty?).to eq(true)
+        end
+      end
+    end
   end
 
   it 'should determine type for attribute' do

--- a/spec/validates_timeliness/orm/active_record_spec.rb
+++ b/spec/validates_timeliness/orm/active_record_spec.rb
@@ -37,24 +37,21 @@ RSpec.describe ValidatesTimeliness, 'ActiveRecord' do
     end
 
     context 'with hash syntax' do
-      let(:klass) do
-        Class.new(ActiveRecord::Base) do
-          self.table_name = 'employees'
-          validates_date :birth_date, { allow_nil: true, allow_blank: true }
-        end
+      class Employee < ActiveRecord::Base
+        validates_date :some_other_date, { allow_nil: true, allow_blank: true }
       end
 
+      let(:record) { Employee.new }
+
       it 'allows nil' do
-        record = klass.new
-        record[:birth_date] = nil
+        record[:some_other_date] = nil
         expect(record.valid?).to eq(true)
         expect(record.errors.empty?).to eq(true)
       end
 
       it 'allows blank' do
-        record = klass.new
         ['', {}, []].each do |blank_val|
-          record[:birth_date] = blank_val
+          record[:some_other_date] = blank_val
           expect(record.valid?).to eq(true)
           expect(record.errors.empty?).to eq(true)
         end


### PR DESCRIPTION
@adzap This adds a spec which should resolve #137, it asserts
  that the `birth_date` field must be a `date` or `nil` or
  `blank` and seems to work.
