### PR TITLE
raise errors in validation procs instead of swallowing them

### DIFF
--- a/lib/generators/validates_timeliness/templates/validates_timeliness.rb
+++ b/lib/generators/validates_timeliness/templates/validates_timeliness.rb
@@ -8,7 +8,11 @@ ValidatesTimeliness.setup do |config|
   # Set the dummy date part for a time type values.
   # config.dummy_date_for_time_type = [ 2000, 1, 1 ]
   #
-  # Ignore errors when restriction options are evaluated
+  # When an exception is raised inside a validation proc, the least surprise
+  # is to raise an exception, but we have other options below.
+  config.reraise_validation_errors = true
+  #
+  # Ignore errors when restriction options are evaluated.   Consider using an :if option to avoid errors and reraising as above
   # config.ignore_restriction_errors = false
   #
   # Re-display invalid values in date/time selects

--- a/lib/validates_timeliness.rb
+++ b/lib/validates_timeliness.rb
@@ -25,7 +25,7 @@ module ValidatesTimeliness
   class << self
     delegate :default_timezone, :default_timezone=, :dummy_date_for_time_type, :dummy_date_for_time_type=, :to => Timeliness
 
-    attr_accessor :extend_orms, :ignore_restriction_errors, :restriction_shorthand_symbols, :use_plugin_parser
+    attr_accessor :extend_orms, :ignore_restriction_errors, :reraise_validation_errors, :restriction_shorthand_symbols, :use_plugin_parser
   end
 
   # Extend ORM/ODMs for full support (:active_record).

--- a/lib/validates_timeliness/railtie.rb
+++ b/lib/validates_timeliness/railtie.rb
@@ -11,5 +11,10 @@ module ValidatesTimeliness
     initializer "validates_timeliness.initialize_restriction_errors" do
       ValidatesTimeliness.ignore_restriction_errors = !Rails.env.test?
     end
+
+    initializer "validates_timeliness.reraise_validation_errors" do
+      ValidatesTimeliness.reraise_validation_errors = false # for backwards compatibility. initializer file should set to true.
+    end
+
   end
 end

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -81,6 +81,7 @@ module ValidatesTimeliness
             add_error(record, attr_name, restriction, restriction_value) and break
           end
         rescue => e
+          raise e if ValidatesTimeliness.reraise_validation_errors
           unless ValidatesTimeliness.ignore_restriction_errors
             message = RESTRICTION_ERROR_MESSAGE % [ attr_name, restriction.inspect, e.message ]
             add_error(record, attr_name, message) and break

--- a/spec/validates_timeliness/validator_spec.rb
+++ b/spec/validates_timeliness/validator_spec.rb
@@ -167,6 +167,26 @@ RSpec.describe ValidatesTimeliness::Validator do
     end
   end
 
+  describe "reraise validation errors" do
+    let(:person) { Person.new(:birth_date => Date.today) }
+
+    before do
+      Person.validates_time :birth_date, :is_at => lambda { raise "oops" }, :before => lambda { raise }
+    end
+
+    it "should raise an error when reraise_validation_errors is true" do
+      with_config(:reraise_validation_errors, true) do
+        expect {person.valid?}.to raise_exception("oops")
+      end
+    end
+
+    it "should not raise an error when reraise_validation_errors is false" do
+      with_config(:reraise_validation_errors, false) do
+        expect {person.valid?}.not_to raise_exception
+      end
+    end
+  end
+
   describe "restriction value errors" do
     let(:person) { Person.new(:birth_date => Date.today) }
 


### PR DESCRIPTION
As we have been discussing in a patch comment thread,  the least surprise would be for the validations to raise errors as the occur, not swallow them.   I think this will give us that without breaking existing systems.
