### PR TITLE
Fix Deprecation warning in Rails5

### DIFF
--- a/lib/validates_timeliness/extensions.rb
+++ b/lib/validates_timeliness/extensions.rb
@@ -1,7 +1,7 @@
+require 'validates_timeliness/extensions/date_time_select'
+
 module ValidatesTimeliness
-  module Extensions
-    autoload :DateTimeSelect, 'validates_timeliness/extensions/date_time_select'
-  end
+  prepend Extensions::DateTimeSelect
 
   def self.enable_date_time_select_extension!
     ::ActionView::Helpers::Tags::DateSelect.send(:include, ValidatesTimeliness::Extensions::DateTimeSelect)

--- a/lib/validates_timeliness/extensions/date_time_select.rb
+++ b/lib/validates_timeliness/extensions/date_time_select.rb
@@ -8,10 +8,6 @@ module ValidatesTimeliness
       # values to be redisplayed instead of blanks to aid correction by the user.
       # It's a minor usability improvement which is rarely an issue for the user.
 
-      included do
-        alias_method_chain :value, :timeliness
-      end
-
       class TimelinessDateTime
         attr_accessor :year, :month, :day, :hour, :min, :sec
 
@@ -32,13 +28,13 @@ module ValidatesTimeliness
         end
       end
 
-      def value_with_timeliness(object)
-        return value_without_timeliness(object) unless @template_object.params[@object_name]
+      def value(object)
+        return super(object) unless @template_object.params[@object_name]
 
         @template_object.params[@object_name]
 
         pairs = @template_object.params[@object_name].select {|k,v| k =~ /^#{@method_name}\(/ }
-        return value_without_timeliness(object) if pairs.empty?
+        return super(object) if pairs.empty?
 
         values = [nil] * 6
         pairs.map do |(param, value)|


### PR DESCRIPTION
https://github.com/adzap/validates_timeliness/issues/143
alias_method_chain is deprecated.
We fixed that it does not support Ruby 1.x.