### PR TITLE
Allow the validator to take in the `message` option too. 

### DIFF
--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -91,7 +91,7 @@ module ValidatesTimeliness
 
     def add_error(record, attr_name, message, value=nil)
       value = format_error_value(value) if value
-      message_options = { :message => options[:"#{message}_message"], :restriction => value }
+      message_options = { :message => (options[:"#{message}_message"] || options[:message]), :restriction => value }
       record.errors.add(attr_name, message, message_options)
     end
 

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -91,7 +91,7 @@ module ValidatesTimeliness
 
     def add_error(record, attr_name, message, value=nil)
       value = format_error_value(value) if value
-      message_options = { :message => (options[:"#{message}_message"] || options[:message]), :restriction => value }
+      message_options = { :message => options.fetch(:"#{message}_message", options[:message]), :restriction => value }
       record.errors.add(attr_name, message, message_options)
     end
 

--- a/spec/validates_timeliness/validator_spec.rb
+++ b/spec/validates_timeliness/validator_spec.rb
@@ -87,6 +87,20 @@ RSpec.describe ValidatesTimeliness::Validator do
     end
   end
 
+  describe ':message options' do
+    it 'should allow message option too' do
+      Person.validates_date :birth_date, on_or_after: :today, message: 'cannot be in past'
+      invalid!(:birth_date, Date.today - 5.days, 'cannot be in past')
+      valid!(:birth_date, Date.today)
+    end
+
+    it 'should first allow the defined message' do
+      Person.validates_date :birth_date, on_or_after: :today, on_or_after_message: 'cannot be in past', message: 'dummy message'
+      invalid!(:birth_date, Date.today - 5.days, 'cannot be in past')
+      valid!(:birth_date, Date.today)
+    end
+  end
+
   describe ":between option" do
     describe "array value" do
       it 'should be split option into :on_or_after and :on_or_before values' do


### PR DESCRIPTION
This is useful in those scenarios where we have a set of generic keys which we need to show.

This would eliminate the need to keeping multiple copies for the default keys set defined by gem.

 The following seems more apt than the later one:

```
    validates_date :start_at, on_or_after: :today, message: 'should not be in past'
```
```
    validates_date :start_at, on_or_after: :today, on_or_after_message: 'should not be in past'
```