### PR TITLE
Fix issue#166 alias_method_chain not working in Rails 5

### DIFF
--- a/lib/validates_timeliness/extensions.rb
+++ b/lib/validates_timeliness/extensions.rb
@@ -1,10 +1,10 @@
 module ValidatesTimeliness
   module Extensions
-    autoload :DateTimeSelect, 'validates_timeliness/extensions/date_time_select'
+    autoload :TimelinessDateTimeSelect, 'validates_timeliness/extensions/date_time_select'
   end
 
   def self.enable_date_time_select_extension!
-    ::ActionView::Helpers::Tags::DateSelect.send(:include, ValidatesTimeliness::Extensions::DateTimeSelect)
+    ::ActionView::Helpers::Tags::DateSelect.send(:prepend, ValidatesTimeliness::Extensions::TimelinessDateTimeSelect)
   end
 
   def self.enable_multiparameter_extension!


### PR DESCRIPTION
Fix issue#166 alias_method_chain not working in Rails 5

Changes include:
* Use `Module.prepend` instead of `alias_method_chain` 
* Combined codes from `DateTimeSelect` and `TimelinessDateTime` into `TimelinessDateTimeSelect`
* Modified `initialize` method as per latest method definition
* Removed `change` method as I did not find it being used for the purpose. Do let me know if it is still needed.
* Renamed `value_with_timeliness` to `value` and modified definition to use changes of `Module.prepend`
* Now `DateTime.new()`, `Time.utc()` or any other similar method works differently
* * Either it does not accept invalid date parameters raising error as 'invalid date'
For example: `DateTime.new(2018, 2, 31, 10, 16, 0)` raises `ArgumentError: invalid date`
* * Or active_record internally converts date to next correct date
For example: `31st February` is converted to `3rd March`
* Due to this changed behaviour, got to change the way value (datetime with errored date parameters) is passed
* Also changed `param.scan(/\((\d+)\w+\)/).first.first` to prettier alternative `param[/\((\d+)\w+\)/, 1]`