### PR TITLE
Fix: Splat args to support Rails 5.0 and 5.2 difference in definition

### DIFF
--- a/lib/validates_timeliness/extensions/date_time_select.rb
+++ b/lib/validates_timeliness/extensions/date_time_select.rb
@@ -32,10 +32,10 @@ module ValidatesTimeliness
 
       # Splat args to support Rails 5.0 which expects object, and 5.2 which doesn't
       def value(*object)
-        return super unless @template_object.params[@object_name]
+        return super(*object) unless @template_object.params[@object_name]
 
         pairs = @template_object.params[@object_name].select {|k,v| k =~ /^#{@method_name}\(/ }
-        return super if pairs.empty?
+        return super(*object) if pairs.empty?
 
         values = {}
         pairs.each_pair do |key, value|


### PR DESCRIPTION
@adzap The changes of splat operator worked great.
Rails 5.2 that I am using is anyway not expecting any args so there was no issue.
But Rails 5 needs args so I think the args needs to be passed to `super` (parent method call)
I have done the changes please merge and confirm.