### PR TITLE
Cleanup: Remove DateTimeValue class

### DIFF
--- a/lib/validates_timeliness/extensions/date_time_select.rb
+++ b/lib/validates_timeliness/extensions/date_time_select.rb
@@ -11,25 +11,6 @@ module ValidatesTimeliness
         :year => 1, :month => 2, :day => 3, :hour => 4, :min => 5, :sec => 6
       }.freeze
 
-      class DateTimeValue
-        attr_accessor :year, :month, :day, :hour, :min, :sec
-
-        def initialize(year:, month:, day: nil, hour: nil, min: nil, sec: nil)
-          @year, @month, @day, @hour, @min, @sec = year, month, day, hour, min, sec
-        end
-
-        def change(options)
-          self.class.new(
-            year:  options.fetch(:year, year),
-            month: options.fetch(:month, month),
-            day:   options.fetch(:day, day),
-            hour:  options.fetch(:hour, hour),
-            min:   options.fetch(:min) { options[:hour] ? 0 : min },
-            sec:   options.fetch(:sec) { options[:hour] || options[:min] ? 0 : sec }
-          )
-        end
-      end
-
       # Splat args to support Rails 5.0 which expects object, and 5.2 which doesn't
       def value(*object)
         return super unless @template_object.params[@object_name]
@@ -43,7 +24,7 @@ module ValidatesTimeliness
           values[POSITION.key(position.to_i)] = value.to_i
         end
 
-        DateTimeValue.new(values)
+        values
       end
     end
   end


### PR DESCRIPTION
@adzap I found that this class is not needed (I may be wrong here) but as I checked and tested I found the code to be working without `DateTimeValue` class.
Passing `values` hash is enough.
Not sure where and when the change method was being invoked.
I am using code by removing class and it is working fine.
Please review and merge PR.