### PR TITLE
Bug fix for variable not initialized when runing rails test

### DIFF
--- a/lib/validates_timeliness/orm/active_record.rb
+++ b/lib/validates_timeliness/orm/active_record.rb
@@ -72,6 +72,7 @@ module ValidatesTimeliness
       end
       
       def read_timeliness_attribute_before_type_cast(attr_name)
+        @timeliness_cache ||= {}
         @timeliness_cache && @timeliness_cache[attr_name] || read_attribute_before_type_cast(attr_name)
       end
 

--- a/lib/validates_timeliness/orm/active_record.rb
+++ b/lib/validates_timeliness/orm/active_record.rb
@@ -32,6 +32,7 @@ module ValidatesTimeliness
         def define_attribute_methods
           super.tap { 
             generated_timeliness_methods.synchronize do
+              @timeliness_methods_generated ||= @timeliness_methods_generated
               return if @timeliness_methods_generated
               define_timeliness_methods true
               @timeliness_methods_generated = true

--- a/lib/validates_timeliness/orm/active_record.rb
+++ b/lib/validates_timeliness/orm/active_record.rb
@@ -32,7 +32,7 @@ module ValidatesTimeliness
         def define_attribute_methods
           super.tap { 
             generated_timeliness_methods.synchronize do
-              @timeliness_methods_generated ||= @timeliness_methods_generated
+              @timeliness_methods_generated ||= nil
               return if @timeliness_methods_generated
               define_timeliness_methods true
               @timeliness_methods_generated = true


### PR DESCRIPTION
Initialize instance variables so that we can silence the warning coming from (instance variable not defined)