### PR TITLE
Fix a wrong monkey patch on overriding ActiveModel::Type::Date

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,3 @@ gem 'byebug'
 gem 'appraisal'
 gem 'sqlite3'
 gem 'nokogiri', '~> 1.8'
-
-group :active_record do
-  gem 'sqlite3-ruby', :require => 'sqlite3'
-end

--- a/lib/validates_timeliness/attribute_methods.rb
+++ b/lib/validates_timeliness/attribute_methods.rb
@@ -11,8 +11,9 @@ end
 
 ActiveModel::Type::Date.class_eval do
   # Module.new do |m|
+    alias_method :_cast_value, :cast_value
     def cast_value(value)
-      return super unless ValidatesTimeliness.use_plugin_parser
+      return _cast_value(value) unless ValidatesTimeliness.use_plugin_parser
 
       if value.is_a?(::String)
         return if value.empty?


### PR DESCRIPTION
```ruby
ActiveModel::Type::Date.class_eval do
  # Module.new do |m|
    def cast_value(value)
      # the `super` is point to `Type::Value#cast_value`, not Type::Date's
      return super unless ValidatesTimeliness.use_plugin_parser

      # ....
    end
  # end.tap { |mod| include mod }
end
```

In addition, `sqlite3-ruby` is no use now, so I remove it.
