### PR TITLE
use ActiveSupport.on_load hook for extend ActiveRecord

### DIFF
--- a/lib/validates_timeliness/orm/active_record.rb
+++ b/lib/validates_timeliness/orm/active_record.rb
@@ -11,7 +11,7 @@ module ValidatesTimeliness
   end
 end
 
-class ActiveRecord::Base
+ActiveSupport.on_load(:active_record) do
   include ValidatesTimeliness::AttributeMethods
   include ValidatesTimeliness::ORM::ActiveRecord
 end


### PR DESCRIPTION
Hi there.

https://github.com/adzap/validates_timeliness/blob/3a2882be7513e587a2029d418dbf9479273cbced/lib/validates_timeliness/orm/active_record.rb#L14

I don't think this extension code is not good.
An error occurred when I use this gem in my application. The application installs this gem and a Mountable Engine that also installs this gem.
When I fixed code as this PR, the error didn't show up, so I think we should change the extend code.

Let me know your opinion.