### PR TITLE
ActiveRecord::Base.default_timezone is deprecated, move to ActiveRecord.default_timezone

### DIFF
--- a/lib/validates_timeliness/railtie.rb
+++ b/lib/validates_timeliness/railtie.rb
@@ -2,7 +2,7 @@ module ValidatesTimeliness
   class Railtie < Rails::Railtie
     initializer "validates_timeliness.initialize_active_record", :after => 'active_record.initialize_timezone' do
       ActiveSupport.on_load(:active_record) do
-        ValidatesTimeliness.default_timezone = ActiveRecord::Base.default_timezone
+        ValidatesTimeliness.default_timezone = ActiveRecord.default_timezone
         ValidatesTimeliness.extend_orms << :active_record
         ValidatesTimeliness.load_orms
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ class PersonWithShim < Person
   include TestModelShim
 end
 
-ActiveRecord::Base.default_timezone = :utc
+ActiveRecord.default_timezone = :utc
 ActiveRecord::Base.time_zone_aware_attributes = true
 ActiveRecord::Base.establish_connection({:adapter => 'sqlite3', :database => ':memory:'})
 ActiveRecord::Base.time_zone_aware_types = [:datetime, :time]


### PR DESCRIPTION
Using `validates_timeliness` in Rails 7.0alpha returns:

```
ActiveRecord::Base.default_timezone is deprecated, move to ActiveRecord.default_timezone
```

so, doing that.