### PR TITLE
Allow to access record value, filled by user in form/API, to be exposed in validation messages

### DIFF
--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -85,7 +85,8 @@ module ValidatesTimeliness
 
     def add_error(record, attr_name, message, value=nil)
       value = format_error_value(value) if value
-      message_options = { :message => options.fetch(:"#{message}_message", options[:message]), :restriction => value }
+      record_value = format_error_value(record.send(attr_name)) if record.respond_to?(attr_name) && record.send(attr_name)
+      message_options = { :message => options.fetch(:"#{message}_message", options[:message]), :restriction => value, :record_value => record_value }
       record.errors.add(attr_name, message, **message_options)
     end
 


### PR DESCRIPTION
Hello, @adzap ! 👋 

This PR has the goal to allows access record value, filled by user in form/API, to be exposed in validation messages 👍 

Let me know your thoughts about it. I can provide later, once merged, this value in gem documentation and in timeliness-i18n gem ( https://github.com/pedrofurtado/timeliness-i18n ).

c/c: @marciojg 🤝 🤓 