### PR TITLE
Take into consideration active record time zone aware flag

### DIFF
--- a/lib/validates_timeliness/railtie.rb
+++ b/lib/validates_timeliness/railtie.rb
@@ -2,7 +2,7 @@ module ValidatesTimeliness
   class Railtie < Rails::Railtie
     initializer "validates_timeliness.initialize_active_record", :after => 'active_record.initialize_timezone' do
       ActiveSupport.on_load(:active_record) do
-        ValidatesTimeliness.default_timezone = ActiveRecord::Base.default_timezone
+        ValidatesTimeliness.default_timezone = ActiveRecord.default_timezone
         ValidatesTimeliness.extend_orms << :active_record
         ValidatesTimeliness.load_orms
       end

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -100,7 +100,7 @@ module ValidatesTimeliness
     end
 
     def time_zone_aware_enabled?
-      defined?(ActiveRecord::Base) ? ActiveRecord::Base.time_zone_aware_attributes : true
+      defined?(ActiveRecord::Base) ? ActiveRecord::Base.time_zone_aware_attributes : false
     end
 
     def class_is_time_zone_aware?(record, attr_name)
@@ -108,7 +108,7 @@ module ValidatesTimeliness
         attr_type = record.class.columns.find { |c| c.name == attr_name.to_s }&.type
         attr_type.present?? ActiveRecord::Base.time_zone_aware_types.include?(attr_type) : false
       else
-        true
+        false
       end
     end
 

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -99,9 +99,23 @@ module ValidatesTimeliness
         record.read_timeliness_attribute_before_type_cast(attr_name.to_s)
     end
 
+    def time_zone_aware_enabled?
+      defined?(ActiveRecord::Base) ? ActiveRecord::Base.time_zone_aware_attributes : true
+    end
+
+    def class_is_time_zone_aware?(record)
+      if defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:time_zone_aware_types)
+        ActiveRecord::Base.time_zone_aware_types.include?(record.class.name.underscore.to_sym)
+      else
+        true
+      end
+    end
+
     def time_zone_aware?(record, attr_name)
-      record.class.respond_to?(:skip_time_zone_conversion_for_attributes) &&
-        !record.class.skip_time_zone_conversion_for_attributes.include?(attr_name.to_sym)
+      time_zone_aware_enabled? &&
+        class_is_time_zone_aware?(record) &&
+          record.class.respond_to?(:skip_time_zone_conversion_for_attributes) &&
+            !record.class.skip_time_zone_conversion_for_attributes.include?(attr_name.to_sym)
     end
 
     def initialize_converter(record, attr_name)

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -104,9 +104,11 @@ module ValidatesTimeliness
     end
 
     def class_is_time_zone_aware?(record, attr_name)
-      if defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:time_zone_aware_types)
-        attr_type = record.class.columns.find { |c| c.name == attr_name.to_s }&.type
-        attr_type.present?? ActiveRecord::Base.time_zone_aware_types.include?(attr_type) : false
+      if defined?(ActiveRecord::Base) && 
+        ActiveRecord::Base.respond_to?(:time_zone_aware_types) &&
+          record.class.respond_to?(:columns) then
+          attr_type = record.class.columns.find { |c| c.name == attr_name.to_s }&.type
+          attr_type.present?? ActiveRecord::Base.time_zone_aware_types.include?(attr_type) : false
       else
         false
       end
@@ -114,7 +116,7 @@ module ValidatesTimeliness
 
     def time_zone_aware?(record, attr_name)
       time_zone_aware_enabled? &&
-        class_is_time_zone_aware?(record) &&
+        class_is_time_zone_aware?(record, attr_name) &&
           record.class.respond_to?(:skip_time_zone_conversion_for_attributes) &&
             !record.class.skip_time_zone_conversion_for_attributes.include?(attr_name.to_sym)
     end

--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -103,9 +103,10 @@ module ValidatesTimeliness
       defined?(ActiveRecord::Base) ? ActiveRecord::Base.time_zone_aware_attributes : true
     end
 
-    def class_is_time_zone_aware?(record)
+    def class_is_time_zone_aware?(record, attr_name)
       if defined?(ActiveRecord::Base) && ActiveRecord::Base.respond_to?(:time_zone_aware_types)
-        ActiveRecord::Base.time_zone_aware_types.include?(record.class.name.underscore.to_sym)
+        attr_type = record.class.columns.find { |c| c.name == attr_name.to_s }&.type
+        attr_type.present?? ActiveRecord::Base.time_zone_aware_types.include?(attr_type) : false
       else
         true
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,7 +57,7 @@ class PersonWithShim < Person
   include TestModelShim
 end
 
-ActiveRecord::Base.default_timezone = :utc
+ActiveRecord.default_timezone = :utc
 ActiveRecord::Base.time_zone_aware_attributes = true
 ActiveRecord::Base.establish_connection({:adapter => 'sqlite3', :database => ':memory:'})
 ActiveRecord::Base.time_zone_aware_types = [:datetime, :time]


### PR DESCRIPTION
When active record has the flag `config.active_record.time_zone_aware_attributes` setted to `false` time zone aware should not used, and same case when attribute class is not included on classes with time zone aware defined by AR too.