### PR TITLE
Support Infinity and -Infinity for date / datetime

### DIFF
--- a/lib/validates_timeliness/converter.rb
+++ b/lib/validates_timeliness/converter.rb
@@ -10,6 +10,7 @@ module ValidatesTimeliness
     end
 
     def type_cast_value(value)
+      return value if infinity?(value) && type_supports_infinity?
       return nil if value.nil? || !value.respond_to?(:to_time)
 
       value = value.in_time_zone if value.acts_like?(:time) && time_zone_aware?
@@ -79,6 +80,14 @@ module ValidatesTimeliness
 
     def time_zone_aware?
       @time_zone_aware
+    end
+
+    def infinity?(value)
+      [Float::INFINITY, -Float::INFINITY].include? value
+    end
+
+    def type_supports_infinity?
+      [:date, :datetime].include? type
     end
   end
 end

--- a/spec/validates_timeliness/converter_spec.rb
+++ b/spec/validates_timeliness/converter_spec.rb
@@ -31,6 +31,14 @@ RSpec.describe ValidatesTimeliness::Converter do
       it 'should return nil for invalid value types' do
         expect(type_cast_value(12)).to eq(nil)
       end
+
+      it "should return the original value for Infinity" do
+        expect(type_cast_value(Float::INFINITY)).to eq Float::INFINITY
+      end
+
+      it "should return the original value for -Infinity" do
+        expect(type_cast_value(-Float::INFINITY)).to eq -Float::INFINITY
+      end
     end
 
     describe "for time type" do
@@ -54,6 +62,14 @@ RSpec.describe ValidatesTimeliness::Converter do
 
       it 'should return nil for invalid value types' do
         expect(type_cast_value(12)).to eq(nil)
+      end
+
+      it "should return nil for Infinity" do
+        expect(type_cast_value(Float::INFINITY)).to eq nil
+      end
+
+      it "should return nil for -Infinity" do
+        expect(type_cast_value(-Float::INFINITY)).to eq nil
       end
     end
 
@@ -83,6 +99,14 @@ RSpec.describe ValidatesTimeliness::Converter do
 
       it 'should return nil for invalid value types' do
         expect(type_cast_value(12)).to eq(nil)
+      end
+
+      it "should return the original value for Infinity" do
+        expect(type_cast_value(Float::INFINITY)).to eq Float::INFINITY
+      end
+
+      it "should return the original value for -Infinity" do
+        expect(type_cast_value(-Float::INFINITY)).to eq -Float::INFINITY
       end
     end
 


### PR DESCRIPTION
This allows validations to proceed accordingly when a user attempts to use infinity or -infinity as a value.