### PR TITLE
fix: converts to a keyword argument

### DIFF
--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -86,7 +86,7 @@ module ValidatesTimeliness
     def add_error(record, attr_name, message, value=nil)
       value = format_error_value(value) if value
       message_options = { message: options.fetch(:"#{message}_message", options[:message]), restriction: value }
-      record.errors.add(attr_name, message, message_options)
+      record.errors.add(attr_name, message, **message_options)
     end
 
     def format_error_value(value)


### PR DESCRIPTION
Use double splat to convert explicitly the hash to keyword arguments. 

This is necessary to keep the same behavior in Ruby 3.

https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/