### PR TITLE
Handle when the passed value is a Numeric value

### DIFF
--- a/lib/validates_timeliness/converter.rb
+++ b/lib/validates_timeliness/converter.rb
@@ -10,7 +10,7 @@ module ValidatesTimeliness
     end
 
     def type_cast_value(value)
-      return nil if value.nil? || !value.respond_to?(:to_time)
+      return nil if value.nil? || !value.respond_to?(:to_time) || value.is_a?(Numeric)
 
       value = value.in_time_zone if value.acts_like?(:time) && time_zone_aware?
       value = case type


### PR DESCRIPTION
When the passed value is a Numeric value, then we get an exception 👇 
=> `NoMethodError: undefined method "to_date" for 444:Integer`

So, this PR is to handle that case!
___
@adzap I hope you like this tiny PR and merge it. 

Regards 🎉 