### PR TITLE
Fix `read_timeliness_attribute_before_type_cast`

### DIFF
--- a/lib/validates_timeliness/orm/active_model.rb
+++ b/lib/validates_timeliness/orm/active_model.rb
@@ -59,7 +59,7 @@ module ValidatesTimeliness
       end
 
       def read_timeliness_attribute_before_type_cast(attr_name)
-        @timeliness_cache && @timeliness_cache[attr_name] || @attributes[attr_name]
+        @timeliness_cache && @timeliness_cache[attr_name] || @attributes[attr_name].value_before_type_cast
       end
 
       def _clear_timeliness_cache

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,7 +22,6 @@ ValidatesTimeliness.setup do |c|
   c.enable_date_time_select_extension!
   c.enable_multiparameter_extension!
   c.default_timezone = :utc
-  c.use_plugin_parser = true
 end
 
 Time.zone = 'Australia/Melbourne'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ ValidatesTimeliness.setup do |c|
   c.enable_date_time_select_extension!
   c.enable_multiparameter_extension!
   c.default_timezone = :utc
+  c.use_plugin_parser = true
 end
 
 Time.zone = 'Australia/Melbourne'

--- a/spec/validates_timeliness/validator/format_spec.rb
+++ b/spec/validates_timeliness/validator/format_spec.rb
@@ -14,6 +14,8 @@ class FormatTestModel
 end
 
 RSpec.describe ValidatesTimeliness::Validator, ":format option" do
+  with_config(:use_plugin_parser, true)
+
   describe "for date type" do
     it "should not be valid for string given in the wrong format" do
       model = FormatTestModel.new(date: "01-01-2010")

--- a/spec/validates_timeliness/validator/format_spec.rb
+++ b/spec/validates_timeliness/validator/format_spec.rb
@@ -1,0 +1,79 @@
+class FormatTestModel
+  include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveModel::Validations
+  include ValidatesTimeliness::ORM::ActiveModel
+
+  attribute :date, :date, default: Date.new
+  attribute :time, :time, default: Time.new
+  attribute :datetime, :time, default: DateTime.new
+
+  validates :date, timeliness: {type: :date, format: "yyyy-mm-dd"}
+  validates :time, timeliness: {type: :time, format: "hh:nn:ss"}
+  validates :datetime, timeliness: {type: :datetime, format: "yyyy-mm-dd hh:nn:ss"}
+end
+
+RSpec.describe ValidatesTimeliness::Validator, ":format option" do
+  describe "for date type" do
+    it "should not be valid for string given in the wrong format" do
+      model = FormatTestModel.new(date: "01-01-2010")
+
+      expect(model).to_not be_valid
+      expect(model.errors.messages_for(:date)).to eq(["is not a valid date"])
+    end
+
+    it "should be valid for string given in the right format" do
+      model = FormatTestModel.new(date: "2010-01-01")
+
+      expect(model).to be_valid, -> { model.errors.full_messages.join("\n") }
+    end
+
+    it "should be valid for date instance" do
+      model = FormatTestModel.new(date: Date.new(2010, 1, 1))
+
+      expect(model).to be_valid, -> { model.errors.full_messages.join("\n") }
+    end
+  end
+
+  describe "for time type" do
+    it "should not be valid for string given in the wrong format" do
+      model = FormatTestModel.new(time: "00-00-00")
+
+      expect(model).to_not be_valid
+      expect(model.errors.messages_for(:time)).to eq(["is not a valid time"])
+    end
+
+    it "should be valid for string given in the right format" do
+      model = FormatTestModel.new(time: "00:00:00")
+
+      expect(model).to be_valid, -> { model.errors.full_messages.join("\n") }
+    end
+
+    it "should be valid for date instance" do
+      model = FormatTestModel.new(time: Time.new(2010, 1, 1, 0, 0, 0))
+
+      expect(model).to be_valid, -> { model.errors.full_messages.join("\n") }
+    end
+  end
+
+  describe "for datetime type" do
+    it "should not be valid for string given in the wrong format" do
+      model = FormatTestModel.new(datetime: "01-01-2010 00-00-00")
+
+      expect(model).to_not be_valid
+      expect(model.errors.messages_for(:datetime)).to eq(["is not a valid datetime"])
+    end
+
+    it "should be valid for string given in the right format" do
+      model = FormatTestModel.new(datetime: "2010-01-01 00:00:00")
+
+      expect(model).to be_valid, -> { model.errors.full_messages.join("\n") }
+    end
+
+    it "should be valid for date instance" do
+      model = FormatTestModel.new(datetime: DateTime.new(2010, 1, 1, 0, 0, 0))
+
+      expect(model).to be_valid, -> { model.errors.full_messages.join("\n") }
+    end
+  end
+end


### PR DESCRIPTION
`@attributes[attr_name]` returns an `ActiveModel::Attribute` not a value, this fixes that.

I'm not familiar enough with how the library works to write a test that hits this code path, all I know is in our codebase validation with `format` doesn't work without this change. All the current tests pass before and after this change, so I don't think any of the existing tests are hitting this code path.