### PR TITLE
ensure options on validations are passed into errors

### DIFF
--- a/lib/validates_timeliness/validator.rb
+++ b/lib/validates_timeliness/validator.rb
@@ -86,7 +86,7 @@ module ValidatesTimeliness
     def add_error(record, attr_name, message, value=nil)
       value = format_error_value(value) if value
       message_options = { message: options.fetch(:"#{message}_message", options[:message]), restriction: value }
-      record.errors.add(attr_name, message, **message_options)
+      record.errors.add(attr_name, message, **options, **message_options)
     end
 
     def format_error_value(value)

--- a/spec/validates_timeliness/validator_spec.rb
+++ b/spec/validates_timeliness/validator_spec.rb
@@ -185,6 +185,27 @@ RSpec.describe ValidatesTimeliness::Validator do
     end
   end
 
+  describe "custom option" do
+    class PersonWithCustomOption
+      include TestModel
+      include TestModelShim
+      attribute :birth_date, :date
+      attribute :birth_time, :time
+      attribute :birth_datetime, :datetime
+      validates_date :birth_date, :format => 'dd-mm-yyyy', :custom_option => "custom option"
+    end
+
+    let(:person) { PersonWithCustomOption.new }
+
+    with_config(:use_plugin_parser, true)
+
+    it "should be included in the errors" do
+      person.birth_date = '1913-12-11'
+      person.valid?
+      expect(person.errors.first.options).to include(:custom_option => "custom option")
+    end
+  end
+
   describe "restriction value errors" do
     let(:person) { Person.new(:birth_date => Date.today) }
 


### PR DESCRIPTION
This PR ensures that the options that are sent in the validation are passed through to errors.

Custom options being set on a validation should be able to be accessed post validation as they would have been set to indicate a validation has failed for some reason.

Added a test case that checks for this.