### PR TITLE
Update README to remove beta from Gemfile instructs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Older Rails versions:
 
 In Gemfile
 ```ruby
-gem 'validates_timeliness', '~> 8.0.0.beta1'
+gem 'validates_timeliness', '~> 8.0.0'
 ```
 
 Run bundler:


### PR DESCRIPTION
Minor README change now that 8.0.0 is out of beta.